### PR TITLE
Allow users to choose start page

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -27,6 +27,7 @@ export default async function handleRequest(
 			onError(error: unknown) {
 				// Log streaming rendering errors from inside the shell
 				console.error(error)
+				// biome-ignore lint: noParameterAssign
 				responseStatusCode = 500
 			},
 		},

--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -7,6 +7,7 @@ import {
 	MusicChannels,
 	type ShortcutConfig,
 	SiteTheme,
+	StartPage,
 	WritingDailyGoalType,
 } from '~/lib/types'
 
@@ -58,6 +59,11 @@ export const SITE_THEMES = [
 	{ value: SiteTheme.LIGHT, label: 'Light' },
 	{ value: SiteTheme.DARK, label: 'Dark' },
 	{ value: SiteTheme.SYSTEM, label: 'System' },
+]
+
+export const START_PAGES = [
+	{ value: StartPage.NEW_POST, label: 'New Post' },
+	{ value: StartPage.VIEW_ALL_POSTS, label: 'View All Posts' },
 ]
 
 export const GENERAL_SHORTCUTS: ShortcutConfig[] = [

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -48,6 +48,11 @@ export enum SiteTheme {
 	SYSTEM = 'system',
 }
 
+export enum StartPage {
+	NEW_POST = 'newPost',
+	VIEW_ALL_POSTS = 'viewAllPosts',
+}
+
 export enum WritingDailyGoalType {
 	DURATION = 'DURATION',
 	WORD_COUNT = 'WORD_COUNT',

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -60,9 +60,9 @@ export const checkSlugUniqueness = async ({
 
 	if (!writing) {
 		return { isUnique: true, slug }
-	} else {
-		return { isUnique: false, slug: '' }
 	}
+
+	return { isUnique: false, slug: '' }
 }
 
 export const convertMsToHumanReadable = (ms: number): string => {
@@ -96,11 +96,12 @@ export const convertMsToHumanReadable = (ms: number): string => {
 
 	if (parts.length === 0) {
 		return '0 seconds'
-	} else if (parts.length === 1) {
-		return parts[0]
-	} else if (parts.length === 2) {
-		return `${parts[0]} and ${parts[1]}`
-	} else {
-		return `${parts.slice(0, -1).join(', ')}, and ${parts[parts.length - 1]}`
 	}
+	if (parts.length === 1) {
+		return parts[0]
+	}
+	if (parts.length === 2) {
+		return `${parts[0]} and ${parts[1]}`
+	}
+	return `${parts.slice(0, -1).join(', ')}, and ${parts[parts.length - 1]}`
 }

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,4 +1,11 @@
-import { Suspense, lazy, useCallback, useEffect, useState } from 'react'
+import {
+	Suspense,
+	lazy,
+	useCallback,
+	useContext,
+	useEffect,
+	useState,
+} from 'react'
 
 import { useLoaderData, useNavigate } from '@remix-run/react'
 
@@ -7,6 +14,11 @@ import SyncFallback from '~/components/common/sync-fallback'
 import { IS_RESTORING_KEY, ROUTES } from '~/lib/constants'
 import { useFirstVisit } from '~/lib/hooks'
 import { loadHelpArticleBySlug } from '~/lib/loaders'
+import {
+	type AureliusProviderData,
+	AureliusContext,
+} from '~/lib/providers/aurelius'
+import { StartPage } from '~/lib/types'
 
 const Editor = lazy(() => import('~/components/common/editor'))
 
@@ -21,6 +33,7 @@ export const clientLoader = async () => {
 }
 
 const Index = () => {
+	const { settings } = useContext<AureliusProviderData>(AureliusContext)
 	const shouldRedirect = useFirstVisit()
 	const { writing } = useLoaderData<typeof clientLoader>()
 	const navigate = useNavigate()
@@ -47,9 +60,16 @@ const Index = () => {
 
 	useEffect(() => {
 		if (shouldRedirect) {
-			navigate(ROUTES.EDITOR.POST, { replace: true }) // Replace with your desired redirect path
+			switch (settings.startPage) {
+				case StartPage.VIEW_ALL_POSTS:
+					navigate(ROUTES.VIEW.POSTS, { replace: true })
+					break
+				case StartPage.NEW_POST:
+					navigate(ROUTES.EDITOR.POST, { replace: true })
+					break
+			}
 		}
-	}, [shouldRedirect, navigate])
+	}, [settings.startPage, shouldRedirect, navigate])
 
 	if (shouldRedirect) {
 		return null // Will be redirected by the useEffect

--- a/app/services/evolu/client.ts
+++ b/app/services/evolu/client.ts
@@ -13,6 +13,7 @@ import {
 	EditorSerifFonts,
 	EditorToolbarMode,
 	MusicChannels,
+	StartPage,
 	WritingDailyGoalType,
 } from '~/lib/types'
 import { Database } from '~/services/evolu/database'
@@ -54,6 +55,9 @@ export const createEvoluClient = () => {
 					MusicChannels.LOFI_HIP_HOP,
 				),
 				showSplashDialog: S.decodeSync(SqliteBoolean)(1),
+				startPage: S.decodeSync(NonEmptyString100)(
+					StartPage.VIEW_ALL_POSTS,
+				),
 				titleFont: S.decodeSync(NonEmptyString100)(
 					EditorSansSerifFonts.INTER,
 				),

--- a/app/services/evolu/schema.ts
+++ b/app/services/evolu/schema.ts
@@ -140,6 +140,7 @@ export const Settings = table({
 	exportImageWatermark: SqliteBoolean,
 	musicChannel: NonEmptyString100,
 	showSplashDialog: S.NullOr(SqliteBoolean),
+	startPage: NonEmptyString100,
 	titleFont: NonEmptyString100,
 	toolbarMode: NonEmptyString100,
 	userName: String1000,


### PR DESCRIPTION
After first visit, the app automatically redirected to the new post page. Now users can choose where they'll be redirected. For now, the available options are new post and view all posts pages.

Fixes: #5 